### PR TITLE
Fixed accidental device disconnection issue

### DIFF
--- a/ConnectionManager.class.nut
+++ b/ConnectionManager.class.nut
@@ -36,13 +36,14 @@ class ConnectionManager {
         _stayConnected = ("stayConnected" in settings) ? settings.stayConnected : false;
         _blinkupBehavior = ("blinkupBehavior" in settings) ? settings.blinkupBehavior : BLINK_ON_DISCONNECT;
         local startDisconnected = ("startDisconnected" in settings) ? settings.startDisconnected : false;
+        local ackTimeout = ("ackTimeout" in settings) ? settings.ackTimeout : 1;
 
         // Initialize the onConnected task queue and logs
         _queue = [];
         _logs = [];
 
         // Set the timeout policy + disconnect if required
-        server.setsendtimeoutpolicy(RETURN_ON_ERROR, WAIT_TIL_SENT, 0);
+        server.setsendtimeoutpolicy(RETURN_ON_ERROR, WAIT_TIL_SENT, ackTimeout);
 
         // Disconnect if required
         if (startDisconnected) {

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The ConnectionManager class can be instantiated with an optional table of settin
 | stayConnected     | `false`             | When set to `true` the device will aggressively attempt to reconnect when disconnected |
 | blinkupBehavior  | BLINK_ON_DISCONNECT | See below |
 | checkTimeout      | 5                   | Changes how often the ConnectionManager checks the connection state (online / offline). |
+| ackTimeout | 1 | Float, seconds. Maximum time (in seconds) allowed for the server to acknowledge receipt of data. |
 
 ```squirrel
 #require "ConnectionManager.class.nut:1.0.1"


### PR DESCRIPTION
Added acknowledgement timeout that defaults to 1 second to avoid accidental device disconnections (due to the TCP buffer overflow).